### PR TITLE
Handle vendored testdata directories properly

### DIFF
--- a/novendor/novendor.go
+++ b/novendor/novendor.go
@@ -234,7 +234,8 @@ func allVendoredPackages(vendorDir string) (map[string]struct{}, error) {
 			}
 		}
 
-		if !dirContainsPkg {
+		// latter can happen in directories like "testdata"
+		if !dirContainsPkg || buildPkgs[0].ImportPath == "." {
 			return nil
 		}
 

--- a/novendor/novendor_test.go
+++ b/novendor/novendor_test.go
@@ -78,6 +78,29 @@ func TestNovendor(t *testing.T) {
 			},
 		},
 		{
+			name: "vendored testdata packages are ignored",
+			files: []gofiles.GoFileSpec{
+				{
+					RelPath: "foo.go",
+					Src:     `package main; import _ "{{index . "vendor/github.com/org/product/bar/bar.go"}}";`,
+				},
+				{
+					RelPath: "vendor/github.com/org/product/bar/bar.go",
+					Src:     `package bar`,
+				},
+				{
+					RelPath: "vendor/github.com/org/product/bar/testdata/data.go",
+					Src: `// +build ignore
+package main`,
+				},
+			},
+			pkgs: func(projectDir string) []string {
+				return []string{
+					projectDir + "/.",
+				}
+			},
+		},
+		{
 			name: "multi-level vendored imports: import a non-external package that uses vendoring to import a package that is visible to the non-external package but not to the base package",
 			files: []gofiles.GoFileSpec{
 				{


### PR DESCRIPTION
Ignore directories if import path is ".".